### PR TITLE
Fix buffer overflow

### DIFF
--- a/lib/xz/stream.rb
+++ b/lib/xz/stream.rb
@@ -118,7 +118,7 @@ class XZ::Stream
       pos = 0
       until pos > str.bytesize # Do not use >=, that conflicts with #lzma_finish
         substr = str[pos, XZ::CHUNK_SIZE]
-        @input_buffer_p[0, str.bytesize] = substr
+        @input_buffer_p[0, substr.bytesize] = substr
         pos += XZ::CHUNK_SIZE
 
         @lzma_stream.next_in  = @input_buffer_p


### PR DESCRIPTION
Passing str bigger than CHUNK_SIZE to XZ::Stream.lzma_code was
causing a buffer overflow on @input_buffer_p.