### PR TITLE
Ignore LZMA_BUF_ERROR

### DIFF
--- a/lib/xz/lib_lzma.rb
+++ b/lib/xz/lib_lzma.rb
@@ -169,8 +169,8 @@ module XZ
       when LibLZMA::LZMA_FORMAT_ERROR   then raise(self, "Unrecognized file format!")
       when LibLZMA::LZMA_OPTIONS_ERROR  then raise(self, "Invalid options passed!")
       when LibLZMA::LZMA_DATA_ERROR     then raise(self, "Archive is currupt.")
-      when LibLZMA::LZMA_BUF_ERROR      then raise(self, "Buffer unusable!")
       when LibLZMA::LZMA_PROG_ERROR     then raise(self, "Program error--if you're sure your code is correct, you may have found a bug in liblzma.")
+      when LibLZMA::LZMA_BUF_ERROR      then # ignore BUF_ERROR since it's not really an error
       end
     end
 


### PR DESCRIPTION
It shouldn't be treated as an error since it is produced when liblzma cannot generate any output yet. The documentation is a little unclear on that matter but this errors seems to be repetitive on some data inputs and ignoring it does not do any harm.

````
	LZMA_BUF_ERROR          = 10,
		/**<
		 * \brief       No progress is possible
		 *
		 * This error code is returned when the coder cannot consume
		 * any new input and produce any new output. The most common
		 * reason for this error is that the input stream being
		 * decoded is truncated or corrupt.
		 *
		 * This error is not fatal. Coding can be continued normally
		 * by providing more input and/or more output space, if
		 * possible.
		 *
		 * Typically the first call to lzma_code() that can do no
		 * progress returns LZMA_OK instead of LZMA_BUF_ERROR. Only
		 * the second consecutive call doing no progress will return
		 * LZMA_BUF_ERROR. This is intentional.
		 *
		 * With zlib, Z_BUF_ERROR may be returned even if the
		 * application is doing nothing wrong, so apps will need
		 * to handle Z_BUF_ERROR specially. The above hack
		 * guarantees that liblzma never returns LZMA_BUF_ERROR
		 * to properly written applications unless the input file
		 * is truncated or corrupt. This should simplify the
		 * applications a little.
		 */
```