### PR TITLE
Add keyword splat to @transcode_options

### DIFF
--- a/lib/xz/stream_reader.rb
+++ b/lib/xz/stream_reader.rb
@@ -250,7 +250,7 @@ class XZ::StreamReader < XZ::Stream
       # Now, transcode it to the internal encoding if that was requested.
       # Otherwise return it with the external encoding as-is.
       if @internal_encoding
-        @readbuf.encode!(@internal_encoding, @transcode_options)
+        @readbuf.encode!(@internal_encoding, **@transcode_options)
         outbuf.force_encoding(@internal_encoding)
       else
         outbuf.force_encoding(@external_encoding)


### PR DESCRIPTION
At least on ruby3.0.0p0, the String#encode! doesn't take a Hash as its second argument, it expects keywords instead.